### PR TITLE
Create dir before coping the gsl content

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,6 +27,7 @@ mv "$VENDOR_DIR/gsl-1.16" "$VENDOR_DIR/gsl"
 # FYI we do this and set the export path explicitly because we cannot assume all buildpacks copy this dir over
 # We need to also leave the vendor dir repo in place, as the current app vendor gets blown away and replaced with
 # what is in the build dir
+mkdir -p "/app/vendor/gsl"
 cp -R "$VENDOR_DIR/gsl" "/app/vendor/gsl"
 
 set-default-env PATH "gsl/bin"


### PR DESCRIPTION
This is an attempt to fix the following error:

```
cp: cannot create directory '/app/vendor/gsl': No such file or directory
```